### PR TITLE
fix: pass full handle array to MKLShim::Create in hipfftCreate

### DIFF
--- a/src/hipfft.cpp
+++ b/src/hipfft.cpp
@@ -23,14 +23,7 @@ hipfftResult hipfftCreate(hipfftHandle *plan)
     // Replace VLA with std::vector
     std::vector<unsigned long> handles(nHandles);
     hipGetBackendNativeHandles((uintptr_t)NULL, handles.data(), 0);
-    char* backendName = (char*)handles[0];
-    // New implementation of hipGetBackendNativeHandles keep backend name in the Native handles
-    // Removing backend name from the list to make it sync to older native handle. This will help Shim layer remains unchanged
-    for(auto i=1; i<nHandles; ++i) {
-        handles[i-1] = handles[i];
-    }
-    handles[nHandles-1] = 0;
-    nHandles--;
+    // MKLShim::Create expects handles[0] = backendName, handles[1..n-1] = native handles
     auto *ctxt = H4I::MKLShim::Create(handles.data(), nHandles);
 
     // assign h->ctxt to use a consistent queue context with CHIP-SPV

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,2 +1,3 @@
+add_subdirectory(hipfft_create)
 add_subdirectory(hipfft_real_1d)
 add_subdirectory(hipfft_complex_1d)

--- a/tests/hipfft_create/CMakeLists.txt
+++ b/tests/hipfft_create/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(hipfft_create_test hipfft_create.cpp)
+
+target_include_directories(hipfft_create_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+target_link_libraries(hipfft_create_test PRIVATE hipfft)
+
+add_test(NAME hipfft_create COMMAND hipfft_create_test)
+set_tests_properties(hipfft_create PROPERTIES
+    PASS_REGULAR_EXPRESSION "PASSED")

--- a/tests/hipfft_create/hipfft_create.cpp
+++ b/tests/hipfft_create/hipfft_create.cpp
@@ -1,0 +1,34 @@
+// Regression test for hipfftCreate() returning a handle with a null context.
+//
+// hipfftCreate() calls hipGetBackendNativeHandles() which returns nHandles=5,
+// where handles[0] is the backend name and handles[1..4] are native
+// platform/device/context/queue handles. A previous bug shifted the array
+// and decremented nHandles to 4 before calling MKLShim::Create(), which
+// requires numOfHandles >= 5 and returned nullptr on this condition,
+// leaving plan->ctxt == nullptr and causing a segfault on first use.
+#include <cstdlib>
+#include <iostream>
+#include "hipfftHandle.h"
+#include "hipfft.h"
+
+int main()
+{
+    hipfftHandle plan = nullptr;
+    hipfftResult result = hipfftCreate(&plan);
+
+    if (result != HIPFFT_SUCCESS) {
+        std::cerr << "FAILED: hipfftCreate returned " << result << std::endl;
+        return EXIT_FAILURE;
+    }
+    if (plan == nullptr) {
+        std::cerr << "FAILED: hipfftCreate returned null handle" << std::endl;
+        return EXIT_FAILURE;
+    }
+    if (plan->ctxt == nullptr) {
+        std::cerr << "FAILED: hipfftCreate handle has null MKLShim context" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "PASSED" << std::endl;
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Problem

`hipfftCreate()` in `src/hipfft.cpp` called `hipGetBackendNativeHandles`
which returns `nHandles=5` values where `handles[0]` is the backend name
string pointer and `handles[1..4]` are the native platform/device/context/
queue handles.

The previous code then shifted all elements down by one and decremented
`nHandles` to 4 before calling `H4I::MKLShim::Create(handles.data(), nHandles)`.
`MKLShim::Create` (in `H4I-MKLShim/src/Context.cpp`) checks:

```cpp
if (numOfHandles < 5)  // prints "Error: Invalid handles", returns nullptr
```

So passing `nHandles=4` caused `Create` to always return `nullptr`, and
the subsequent dereference of `h->ctxt` segfaulted.

## Fix

Remove the shifting loop, the zeroing of the last slot, and the
`nHandles--` decrement.  Pass the full, unmodified array directly to
`Create`, which is the pattern already used by H4I-HipBLAS `src/util.cpp`:

```cpp
std::vector<unsigned long> handles(nHandles);
hipGetBackendNativeHandles((uintptr_t)NULL, handles.data(), 0);
auto *ctxt = H4I::MKLShim::Create(handles.data(), nHandles);
```

`MKLShim::Create` reads `handles[BACKEND_NAME]` (index 0) as the name
and `handles[1..4]` as native handles, so the full array is exactly what
it expects.