### PR TITLE
cmake: add hipfft-config.cmake for find_package(hipfft) support

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -36,8 +36,36 @@ jobs:
           module load oneapi/2025.0.4 llvm/22.0-native HIP/chipStar/main level-zero/dgpu HIP/H4I-MKLShim/oneapi-2025.0.4
           module list
           rm -rf build
+          INSTALL_PREFIX="$PWD/build/install"
           cmake -S . -B build \
             -DCMAKE_CXX_COMPILER="$(which hipcc)" \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           cmake --build build -j 8
+          cmake --install build
+      - name: Consumer find_package test
+        shell: bash
+        run: |
+          set -e
+          if [ -f "$HOME/.local/init/bash" ]; then
+            export MODULESHOME=$HOME/.local
+            source "$MODULESHOME/init/bash"
+          elif [ -f /etc/profile.d/lmod.sh ]; then
+            source /etc/profile.d/lmod.sh
+          else
+            source /etc/profile.d/modules.sh
+          fi
+          module use /space/pvelesko/modulefiles
+          module load oneapi/2025.0.4 llvm/22.0-native HIP/chipStar/main level-zero/dgpu HIP/H4I-MKLShim/oneapi-2025.0.4
+          INSTALL_PREFIX="$PWD/build/install"
+          rm -rf tests/cmake-consumer/build
+          cmake -S tests/cmake-consumer -B tests/cmake-consumer/build \
+            -DCMAKE_CXX_COMPILER="$(which hipcc)" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_PREFIX_PATH="$INSTALL_PREFIX" \
+            -Dhipfft_DIR="$INSTALL_PREFIX/lib/cmake/hipfft" \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+          cmake --build tests/cmake-consumer/build -j 8
+          test -x tests/cmake-consumer/build/consumer
+          echo "Consumer binary built successfully: $(file tests/cmake-consumer/build/consumer)"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,10 +102,14 @@ target_compile_options(hipfft PRIVATE -fsycl)
 target_link_options(hipfft PRIVATE -fsycl)
 
 # Add the directory containing hipfftHandle.h to the include directories
-target_include_directories(hipfft PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_include_directories(hipfft PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
 
 # Installation rules
 install(TARGETS hipfft
+    EXPORT hipfftTargets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -114,6 +118,36 @@ install(TARGETS hipfft
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     FILES_MATCHING PATTERN "*.h"
+)
+
+# Export CMake package config so consumers can do find_package(hipfft CONFIG)
+# and link against hip::hipfft.
+include(CMakePackageConfigHelpers)
+
+set(HIPFFT_CMAKE_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/hipfft)
+
+install(EXPORT hipfftTargets
+    FILE hipfftTargets.cmake
+    NAMESPACE hip::
+    DESTINATION ${HIPFFT_CMAKE_INSTALL_DIR}
+)
+
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/hipfft-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/hipfft-config.cmake
+    INSTALL_DESTINATION ${HIPFFT_CMAKE_INSTALL_DIR}
+)
+
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/hipfft-config-version.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/hipfft-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/hipfft-config-version.cmake
+    DESTINATION ${HIPFFT_CMAKE_INSTALL_DIR}
 )
 
 include(CTest)

--- a/cmake/hipfft-config.cmake.in
+++ b/cmake/hipfft-config.cmake.in
@@ -1,0 +1,9 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(hip CONFIG)
+find_dependency(MKLShim CONFIG)
+
+include("${CMAKE_CURRENT_LIST_DIR}/hipfftTargets.cmake")
+
+check_required_components(hipfft)

--- a/tests/cmake-consumer/CMakeLists.txt
+++ b/tests/cmake-consumer/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Standalone consumer project that exercises find_package(hipfft CONFIG).
+# This is intentionally NOT added via add_subdirectory from the top-level
+# build; CI configures it separately against an installed hipfft so that
+# the install-time CMake package config is what's actually tested.
+cmake_minimum_required(VERSION 3.20)
+
+project(hipfft_consumer LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_compile_definitions(__HIP_PLATFORM_SPIRV__)
+
+find_package(hip CONFIG REQUIRED)
+find_package(hipfft CONFIG REQUIRED)
+
+add_executable(consumer consumer.cpp)
+target_link_libraries(consumer PRIVATE hip::hipfft)

--- a/tests/cmake-consumer/consumer.cpp
+++ b/tests/cmake-consumer/consumer.cpp
@@ -1,0 +1,22 @@
+// Minimal consumer that links against an installed hipfft via
+// find_package(hipfft CONFIG). The purpose is to verify the install-time
+// CMake package config exposes a usable hip::hipfft target with correct
+// include directories and link dependencies. No real FFT work is done.
+#include <cstdlib>
+#include <iostream>
+
+#include <hipfft.h>
+
+int main()
+{
+    hipfftHandle plan = nullptr;
+    hipfftResult result = hipfftCreate(&plan);
+    if (result != HIPFFT_SUCCESS) {
+        std::cerr << "FAILED: hipfftCreate returned " << result << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "PASSED: find_package(hipfft CONFIG) consumer linked and ran"
+              << std::endl;
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Adds a CMake package config so downstream projects can do `find_package(hipfft CONFIG)` and link against the `hip::hipfft` target, matching AMD's HIP convention.