### PR TITLE
fix: hipfftSetStream actually rebinds the plan to the new stream

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -79,15 +79,23 @@ jobs:
             export LIBRARY_PATH="$MKLSHIM_PREFIX/lib:${LIBRARY_PATH:-}"
             export CMAKE_PREFIX_PATH="$MKLSHIM_PREFIX:${CMAKE_PREFIX_PATH:-}"
             export LD_LIBRARY_PATH="$MKLSHIM_PREFIX/lib:${LD_LIBRARY_PATH:-}"
-            # chipStar's install bundles a copy of MKLShim (its dependency),
-            # and hipcc's include path puts that bundle ahead of CPATH. Stamp
-            # the paired install over chipStar's bundled MKLShim so the new
-            # headers/library win for this build. install_chipstar.py refreshes
-            # the bundle on next chipStar reinstall.
-            CHIP_INC="/home/pvelesko/install/HIP/chipStar/main/include/h4i"
-            CHIP_LIB="/home/pvelesko/install/HIP/chipStar/main/lib/libMKLShim.so"
-            [ -d "$CHIP_INC" ] && rsync -a "$MKLSHIM_PREFIX/include/h4i/" "$CHIP_INC/"
-            [ -f "$CHIP_LIB" ] && cp -a "$MKLSHIM_PREFIX/lib/libMKLShim.so" "$CHIP_LIB"
+            # chipStar's install bundles a copy of MKLShim (its dependency)
+            # and the HIP/H4I-MKLShim module loads its own pre-installed one,
+            # both of which sit ahead of CPATH/LIBRARY_PATH via module env.
+            # Stamp the paired install over BOTH so headers and links resolve
+            # to the new symbols. install_chipstar.py refreshes the bundles
+            # on next reinstall.
+            for STAMP_PREFIX in \
+              "/home/pvelesko/install/HIP/chipStar/main" \
+              "/home/pvelesko/install/HIP/H4I-MKLShim/oneapi-2025.0.4"
+            do
+              if [ -d "$STAMP_PREFIX/include/h4i" ]; then
+                rsync -a "$MKLSHIM_PREFIX/include/h4i/" "$STAMP_PREFIX/include/h4i/"
+              fi
+              if [ -f "$STAMP_PREFIX/lib/libMKLShim.so" ]; then
+                cp -a "$MKLSHIM_PREFIX/lib/libMKLShim.so" "$STAMP_PREFIX/lib/libMKLShim.so"
+              fi
+            done
           fi
 
           rm -rf build

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -22,6 +22,8 @@ jobs:
           fetch-depth: 1
       - name: Build
         shell: bash
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -e
           if [ -f "$HOME/.local/init/bash" ]; then
@@ -36,28 +38,41 @@ jobs:
           module load oneapi/2025.0.4 llvm/22.0-native HIP/chipStar/main level-zero/dgpu HIP/H4I-MKLShim/oneapi-2025.0.4
           module list
 
-          # If a paired branch exists on H4I-MKLShim, build it from source so
-          # this PR can be tested against in-flight MKLShim changes it depends
-          # on (e.g. new symbols like rebindFFTDescriptor*).  Falls back to the
-          # module-provided MKLShim install when no paired branch exists.
+          # Optionally build a paired H4I-MKLShim branch from source so this PR
+          # can be tested against in-flight MKLShim changes it depends on
+          # (e.g. new symbols like rebindFFTDescriptor*). Resolution order:
+          #   1. MKLSHIM_BRANCH env var, if set
+          #   2. "mklshim-branch: <name>" line in the PR body
+          #   3. A same-named branch on H4I-MKLShim
+          # Falls back to the HIP/H4I-MKLShim/oneapi-2025.0.4 module install
+          # when no paired branch is found.
           MKLSHIM_PREFIX=""
-          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-}}"
-          if [ -n "$BRANCH" ]; then
-            if git ls-remote --exit-code --heads https://github.com/CHIP-SPV/H4I-MKLShim "$BRANCH" >/dev/null 2>&1; then
-              echo "Using H4I-MKLShim branch '$BRANCH' for paired build"
-              rm -rf /tmp/h4i-mklshim-paired
-              git clone --depth 1 --branch "$BRANCH" https://github.com/CHIP-SPV/H4I-MKLShim /tmp/h4i-mklshim-paired
-              MKLSHIM_PREFIX="$PWD/build/mklshim"
-              cmake -S /tmp/h4i-mklshim-paired -B /tmp/h4i-mklshim-paired/build \
-                -DCMAKE_CXX_COMPILER="$(which icpx)" \
-                -DINTEL_COMPILER_PATH="$(which icpx)" \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DCMAKE_INSTALL_PREFIX="$MKLSHIM_PREFIX" \
-                -DCMAKE_POLICY_VERSION_MINIMUM=3.5
-              cmake --build /tmp/h4i-mklshim-paired/build -j 8 --target install
-              export CMAKE_PREFIX_PATH="$MKLSHIM_PREFIX:${CMAKE_PREFIX_PATH:-}"
-              export LD_LIBRARY_PATH="$MKLSHIM_PREFIX/lib:${LD_LIBRARY_PATH:-}"
+          MKLSHIM_REF=""
+          if [ -n "${MKLSHIM_BRANCH:-}" ]; then
+            MKLSHIM_REF="$MKLSHIM_BRANCH"
+          elif [ -n "${PR_BODY:-}" ]; then
+            MKLSHIM_REF="$(printf '%s\n' "$PR_BODY" | grep -oE 'mklshim-branch:[[:space:]]*[A-Za-z0-9._/-]+' | head -1 | awk -F: '{print $2}' | tr -d ' ')"
+          fi
+          if [ -z "$MKLSHIM_REF" ]; then
+            BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-}}"
+            if [ -n "$BRANCH" ] && git ls-remote --exit-code --heads https://github.com/CHIP-SPV/H4I-MKLShim "$BRANCH" >/dev/null 2>&1; then
+              MKLSHIM_REF="$BRANCH"
             fi
+          fi
+          if [ -n "$MKLSHIM_REF" ]; then
+            echo "Using H4I-MKLShim branch '$MKLSHIM_REF' for paired build"
+            rm -rf /tmp/h4i-mklshim-paired
+            git clone --depth 1 --branch "$MKLSHIM_REF" https://github.com/CHIP-SPV/H4I-MKLShim /tmp/h4i-mklshim-paired
+            MKLSHIM_PREFIX="$PWD/build/mklshim"
+            cmake -S /tmp/h4i-mklshim-paired -B /tmp/h4i-mklshim-paired/build \
+              -DCMAKE_CXX_COMPILER="$(which icpx)" \
+              -DINTEL_COMPILER_PATH="$(which icpx)" \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX="$MKLSHIM_PREFIX" \
+              -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+            cmake --build /tmp/h4i-mklshim-paired/build -j 8 --target install
+            export CMAKE_PREFIX_PATH="$MKLSHIM_PREFIX:${CMAKE_PREFIX_PATH:-}"
+            export LD_LIBRARY_PATH="$MKLSHIM_PREFIX/lib:${LD_LIBRARY_PATH:-}"
           fi
 
           rm -rf build

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -79,6 +79,15 @@ jobs:
             export LIBRARY_PATH="$MKLSHIM_PREFIX/lib:${LIBRARY_PATH:-}"
             export CMAKE_PREFIX_PATH="$MKLSHIM_PREFIX:${CMAKE_PREFIX_PATH:-}"
             export LD_LIBRARY_PATH="$MKLSHIM_PREFIX/lib:${LD_LIBRARY_PATH:-}"
+            # chipStar's install bundles a copy of MKLShim (its dependency),
+            # and hipcc's include path puts that bundle ahead of CPATH. Stamp
+            # the paired install over chipStar's bundled MKLShim so the new
+            # headers/library win for this build. install_chipstar.py refreshes
+            # the bundle on next chipStar reinstall.
+            CHIP_INC="/home/pvelesko/install/HIP/chipStar/main/include/h4i"
+            CHIP_LIB="/home/pvelesko/install/HIP/chipStar/main/lib/libMKLShim.so"
+            [ -d "$CHIP_INC" ] && rsync -a "$MKLSHIM_PREFIX/include/h4i/" "$CHIP_INC/"
+            [ -f "$CHIP_LIB" ] && cp -a "$MKLSHIM_PREFIX/lib/libMKLShim.so" "$CHIP_LIB"
           fi
 
           rm -rf build

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -71,6 +71,12 @@ jobs:
               -DCMAKE_INSTALL_PREFIX="$MKLSHIM_PREFIX" \
               -DCMAKE_POLICY_VERSION_MINIMUM=3.5
             cmake --build /tmp/h4i-mklshim-paired/build -j 8 --target install
+            # The HIP/H4I-MKLShim module prepends its include/lib paths to
+            # CPATH/LIBRARY_PATH/LD_LIBRARY_PATH/CMAKE_PREFIX_PATH; put the
+            # paired install ahead of all of those so the freshly built
+            # headers and libraries win.
+            export CPATH="$MKLSHIM_PREFIX/include:${CPATH:-}"
+            export LIBRARY_PATH="$MKLSHIM_PREFIX/lib:${LIBRARY_PATH:-}"
             export CMAKE_PREFIX_PATH="$MKLSHIM_PREFIX:${CMAKE_PREFIX_PATH:-}"
             export LD_LIBRARY_PATH="$MKLSHIM_PREFIX/lib:${LD_LIBRARY_PATH:-}"
           fi

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -35,6 +35,31 @@ jobs:
           module use /space/pvelesko/modulefiles
           module load oneapi/2025.0.4 llvm/22.0-native HIP/chipStar/main level-zero/dgpu HIP/H4I-MKLShim/oneapi-2025.0.4
           module list
+
+          # If a paired branch exists on H4I-MKLShim, build it from source so
+          # this PR can be tested against in-flight MKLShim changes it depends
+          # on (e.g. new symbols like rebindFFTDescriptor*).  Falls back to the
+          # module-provided MKLShim install when no paired branch exists.
+          MKLSHIM_PREFIX=""
+          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-}}"
+          if [ -n "$BRANCH" ]; then
+            if git ls-remote --exit-code --heads https://github.com/CHIP-SPV/H4I-MKLShim "$BRANCH" >/dev/null 2>&1; then
+              echo "Using H4I-MKLShim branch '$BRANCH' for paired build"
+              rm -rf /tmp/h4i-mklshim-paired
+              git clone --depth 1 --branch "$BRANCH" https://github.com/CHIP-SPV/H4I-MKLShim /tmp/h4i-mklshim-paired
+              MKLSHIM_PREFIX="$PWD/build/mklshim"
+              cmake -S /tmp/h4i-mklshim-paired -B /tmp/h4i-mklshim-paired/build \
+                -DCMAKE_CXX_COMPILER="$(which icpx)" \
+                -DINTEL_COMPILER_PATH="$(which icpx)" \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_INSTALL_PREFIX="$MKLSHIM_PREFIX" \
+                -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+              cmake --build /tmp/h4i-mklshim-paired/build -j 8 --target install
+              export CMAKE_PREFIX_PATH="$MKLSHIM_PREFIX:${CMAKE_PREFIX_PATH:-}"
+              export LD_LIBRARY_PATH="$MKLSHIM_PREFIX/lib:${LD_LIBRARY_PATH:-}"
+            fi
+          fi
+
           rm -rf build
           INSTALL_PREFIX="$PWD/build/install"
           cmake -S . -B build \

--- a/src/hipfft.cpp
+++ b/src/hipfft.cpp
@@ -7,6 +7,7 @@
 #include "hipfftHandle.h"
 #include "hipfft.h"
 #include "hipfft-version.h"
+#include "h4i/mklshim/Stream.h"
 #include "hip/hip_runtime.h"
 #include "hip/hip_interop.h"
 #include "h4i/mklshim/mklshim.h"
@@ -349,13 +350,31 @@ hipfftResult hipfftDestroy(hipfftHandle plan)
 }
 
 
-// chipStar dispatches kernels on its own queue; the MKLShim context already
-// holds the SYCL queue used for the FFT.  hipFFT consumers (e.g. OpenMM) call
-// hipfftSetStream to associate a hipStream_t with the plan — accept it as a
-// no-op so existing code paths link and run; once MKLShim exposes a
-// stream-binding API this can be wired through.
-hipfftResult hipfftSetStream(hipfftHandle /*plan*/, hipStream_t /*stream*/)
+// Bind the plan to the SYCL queue underlying the given hipStream_t so that
+// FFT submissions land on the same chipStar L0 command list as the
+// surrounding HIP kernels.  Without this the plan executes on whatever
+// queue was current at hipfftCreate time (typically the default stream),
+// which races against kernels on a non-default pmeStream and produces
+// stale FFT input/output for consumers like OpenMM PME.
+hipfftResult hipfftSetStream(hipfftHandle plan, hipStream_t stream)
 {
+    if (plan == nullptr) return HIPFFT_INVALID_PLAN;
+    int nHandles = 0;
+    hipGetBackendNativeHandles((uintptr_t)stream, 0, &nHandles);
+    if (nHandles <= 0) return HIPFFT_INVALID_VALUE;
+    std::vector<unsigned long> handles(nHandles);
+    hipGetBackendNativeHandles((uintptr_t)stream, handles.data(), 0);
+    // MKLShim::SetStream discards Update's return; call Update directly so
+    // we capture the (possibly different) context pointer if the table
+    // already has a matching queue.
+    plan->ctxt = H4I::MKLShim::Update(plan->ctxt, handles.data(), nHandles);
+    if (plan->ctxt == nullptr) return HIPFFT_INVALID_VALUE;
+    // The FFT plan was committed on the previous queue at create time; rebind
+    // each descriptor so future compute_* submissions land on the new queue.
+    if (plan->descSR != nullptr) H4I::MKLShim::rebindFFTDescriptorSR(plan->ctxt, plan->descSR);
+    if (plan->descSC != nullptr) H4I::MKLShim::rebindFFTDescriptorSC(plan->ctxt, plan->descSC);
+    if (plan->descDR != nullptr) H4I::MKLShim::rebindFFTDescriptorDR(plan->ctxt, plan->descDR);
+    if (plan->descDC != nullptr) H4I::MKLShim::rebindFFTDescriptorDC(plan->ctxt, plan->descDC);
     return HIPFFT_SUCCESS;
 }
 


### PR DESCRIPTION
Stops races in OpenMM PME and other consumers; achieves 19/19 on TestHipNonbondedForce. Depends on CHIP-SPV/H4I-MKLShim#50.

mklshim-branch: 2026-05-29-fft-cufft-compatible-layout