### PR TITLE
ci: add install.yml (refresh shared HipFFT module on main)

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,0 +1,42 @@
+name: H4I-HipFFT Install
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  install:
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build & install H4I-HipFFT (oneapi/2025.0.4)
+        shell: bash
+        run: |
+          set -e
+          if [ -f "$HOME/.local/init/bash" ]; then
+            export MODULESHOME=$HOME/.local
+            source "$MODULESHOME/init/bash"
+          elif [ -f /etc/profile.d/lmod.sh ]; then
+            source /etc/profile.d/lmod.sh
+          else
+            source /etc/profile.d/modules.sh
+          fi
+          module use /space/pvelesko/modulefiles
+          module load oneapi/2025.0.4 llvm/22.0-native HIP/chipStar/main level-zero/dgpu HIP/H4I-MKLShim/oneapi-2025.0.4
+          module list
+
+          PREFIX=/home/pvelesko/install/HIP/H4I-HipFFT/oneapi-2025.0.4
+          rm -rf build
+          cmake -S . -B build \
+            -DCMAKE_CXX_COMPILER="$(which hipcc)" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+          cmake --build build -j 8 --target install

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -63,6 +63,7 @@ jobs:
             -DCMAKE_CXX_COMPILER="$(which icpx)" \
             -DINTEL_COMPILER_PATH="$(which icpx)" \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_PREFIX_PATH="$DEPS/chipstar" \
             -DCMAKE_INSTALL_PREFIX="$DEPS/mklshim" \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           cmake --build "$SRC/H4I-MKLShim/build" -j 8 --target install

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -20,6 +20,54 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
+      - name: Build chipStar + H4I-MKLShim from source
+        shell: bash
+        run: |
+          set -e
+          if [ -f "$HOME/.local/init/bash" ]; then
+            export MODULESHOME=$HOME/.local
+            source "$MODULESHOME/init/bash"
+          elif [ -f /etc/profile.d/lmod.sh ]; then
+            source /etc/profile.d/lmod.sh
+          else
+            source /etc/profile.d/modules.sh
+          fi
+          module use /space/pvelesko/modulefiles
+          module load oneapi/2025.0.4 llvm/22.0-native level-zero/dgpu
+          module list
+
+          # Build chipStar and H4I-MKLShim from source into a job-local prefix
+          # instead of relying on the system module installs. Everything is
+          # built, installed, and consumed within this job, so the install is
+          # self-consistent (no external staging paths to go stale).
+          DEPS="$PWD/deps"
+          SRC="$RUNNER_TEMP/dep-src"
+          rm -rf "$DEPS" "$SRC"
+          mkdir -p "$SRC"
+
+          # chipStar: library only (no tests, no samples) -- builds fast.
+          git clone --depth 1 --recurse-submodules --shallow-submodules \
+            https://github.com/CHIP-SPV/chipStar "$SRC/chipStar"
+          cmake -S "$SRC/chipStar" -B "$SRC/chipStar/build" -G Ninja \
+            -DLLVM_CONFIG_BIN="$(which llvm-config)" \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCHIP_BUILD_TESTS=OFF \
+            -DCHIP_BUILD_SAMPLES=OFF \
+            -DCMAKE_INSTALL_PREFIX="$DEPS/chipstar"
+          ninja -C "$SRC/chipStar/build"
+          cmake --install "$SRC/chipStar/build"
+
+          # H4I-MKLShim: built with icpx.
+          git clone --depth 1 https://github.com/CHIP-SPV/H4I-MKLShim "$SRC/H4I-MKLShim"
+          cmake -S "$SRC/H4I-MKLShim" -B "$SRC/H4I-MKLShim/build" \
+            -DCMAKE_CXX_COMPILER="$(which icpx)" \
+            -DINTEL_COMPILER_PATH="$(which icpx)" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$DEPS/mklshim" \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+          cmake --build "$SRC/H4I-MKLShim/build" -j 8 --target install
+
+          echo "DEPS=$DEPS" >> "$GITHUB_ENV"
       - name: Build
         shell: bash
         run: |
@@ -33,13 +81,14 @@ jobs:
             source /etc/profile.d/modules.sh
           fi
           module use /space/pvelesko/modulefiles
-          module load oneapi/2025.0.4 llvm/22.0-native HIP/chipStar/main level-zero/dgpu HIP/H4I-MKLShim/oneapi-2025.0.4
-          module list
+          module load oneapi/2025.0.4 llvm/22.0-native level-zero/dgpu
+          export CMAKE_PREFIX_PATH="$DEPS/chipstar:$DEPS/mklshim:${CMAKE_PREFIX_PATH:-}"
+          export LD_LIBRARY_PATH="$DEPS/chipstar/lib:$DEPS/mklshim/lib:${LD_LIBRARY_PATH:-}"
 
           rm -rf build
           INSTALL_PREFIX="$PWD/build/install"
           cmake -S . -B build \
-            -DCMAKE_CXX_COMPILER="$(which hipcc)" \
+            -DCMAKE_CXX_COMPILER="$DEPS/chipstar/bin/hipcc" \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5
@@ -58,7 +107,9 @@ jobs:
             source /etc/profile.d/modules.sh
           fi
           module use /space/pvelesko/modulefiles
-          module load oneapi/2025.0.4 llvm/22.0-native HIP/chipStar/main level-zero/dgpu HIP/H4I-MKLShim/oneapi-2025.0.4
+          module load oneapi/2025.0.4 llvm/22.0-native level-zero/dgpu
+          export CMAKE_PREFIX_PATH="$DEPS/chipstar:$DEPS/mklshim:${CMAKE_PREFIX_PATH:-}"
+          export LD_LIBRARY_PATH="$DEPS/chipstar/lib:$DEPS/mklshim/lib:${LD_LIBRARY_PATH:-}"
           # D2Z/Z2D tests exercise double precision; the Arc A380 needs FP64
           # emulation enabled to run them.
           export IGC_EnableDPEmulation=1
@@ -77,13 +128,15 @@ jobs:
             source /etc/profile.d/modules.sh
           fi
           module use /space/pvelesko/modulefiles
-          module load oneapi/2025.0.4 llvm/22.0-native HIP/chipStar/main level-zero/dgpu HIP/H4I-MKLShim/oneapi-2025.0.4
+          module load oneapi/2025.0.4 llvm/22.0-native level-zero/dgpu
+          export CMAKE_PREFIX_PATH="$DEPS/chipstar:$DEPS/mklshim:${CMAKE_PREFIX_PATH:-}"
+          export LD_LIBRARY_PATH="$DEPS/chipstar/lib:$DEPS/mklshim/lib:${LD_LIBRARY_PATH:-}"
           INSTALL_PREFIX="$PWD/build/install"
           rm -rf tests/cmake-consumer/build
           cmake -S tests/cmake-consumer -B tests/cmake-consumer/build \
-            -DCMAKE_CXX_COMPILER="$(which hipcc)" \
+            -DCMAKE_CXX_COMPILER="$DEPS/chipstar/bin/hipcc" \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_PREFIX_PATH="$INSTALL_PREFIX" \
+            -DCMAKE_PREFIX_PATH="$INSTALL_PREFIX;$DEPS/chipstar;$DEPS/mklshim" \
             -Dhipfft_DIR="$INSTALL_PREFIX/lib/cmake/hipfft" \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           cmake --build tests/cmake-consumer/build -j 8


### PR DESCRIPTION
HipFFT was the only live H4I repo without an `install.yml`, so its installed module was only ever hand-updated (stale, pre-D2Z/Z2D-fix) and used a date-stamped prefix instead of the `oneapi-2025.0.4` convention.

Adds `install.yml` mirroring `presubmit.yml`'s build (hipcc, `/space/pvelesko/modulefiles`, `llvm/22.0-native`), triggering on push to `main`, installing to `/home/pvelesko/install/HIP/H4I-HipFFT/oneapi-2025.0.4` — consistent with the other H4I libraries.

Validated via `workflow_dispatch` on this branch before merge.